### PR TITLE
パスワードリセットの修正

### DIFF
--- a/app/Notifications/UserResetPassword.php
+++ b/app/Notifications/UserResetPassword.php
@@ -49,7 +49,7 @@ class UserResetPassword extends Resetpassword
         return (new MailMessage)
             ->subject(Lang::get('Reset Password Notification'))
             ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
-            ->action(Lang::get('Reset Password'), url(route('reset', ['token' => $this->token, 'email' => $notifiable->getEmailForPasswordReset()], false)))
+            ->action(Lang::get('Reset Password'), url(route('password.reset', ['token' => $this->token, 'email' => $notifiable->getEmailForPasswordReset()], false)))
             ->line(Lang::get('This password reset link will expire in :count minutes.', ['count' => config('auth.passwords.' . config('auth.defaults.passwords') . '.expire')]))
             ->line(Lang::get('If you did not request a password reset, no further action is required.'));
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,8 +3,13 @@
 Route::get('/home', 'HomeController@index')->name('home');
 
 // reset password callback
-Route::get('/reset-password/{token}', 'Auth\ResetPasswordController@resetPassword')
-    ->name('reset-password');
+Route::get('/reset-password/{token}', 'Auth\ResetPasswordController@showResetForm')
+    ->name('password.reset');
+
+// reset password
+Route::post('/password/reset', 'Auth\ResetPasswordController@reset')
+    ->name('password.update');
+
 
 Route::get('/{any}', function () {
     return view('index');


### PR DESCRIPTION
## 概要
パスワードリセットの修正

## 対応詳細
- パスワードリセットのルーティングを修正しました

## 確認方法
①ふつうに会員登録
http://localhost:8000/user/login

②ログアウト
ログアウト機能が実装されていないのでとりあえずcookie削除

③パスワードリセットメール送信
![スクリーンショット 2021-05-26 19 51 58](https://user-images.githubusercontent.com/31526134/119650213-860af380-be5e-11eb-8ffe-9a41a01993fe.png)

④送信されたメールからパスワードリセットのリンクをクリック

⑤パスワードをリセット
![スクリーンショット 2021-05-26 19 53 50](https://user-images.githubusercontent.com/31526134/119650297-9c18b400-be5e-11eb-99ef-52cd0b10ea13.png)

⑥ログイン状態になるので、一度ログアウト（cookie削除）

⑦新しいパスワードでログイン
